### PR TITLE
Update category to cascade delete to skills.

### DIFF
--- a/src/main/java/com/excella/reactor/domain/DomainModel.java
+++ b/src/main/java/com/excella/reactor/domain/DomainModel.java
@@ -1,7 +1,5 @@
 package com.excella.reactor.domain;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import java.io.Serializable;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -13,7 +11,6 @@ import lombok.Setter;
 @Getter
 @Setter
 @MappedSuperclass
-@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public abstract class DomainModel implements Serializable {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Id

--- a/src/main/java/com/excella/reactor/domain/Skill.java
+++ b/src/main/java/com/excella/reactor/domain/Skill.java
@@ -2,6 +2,8 @@ package com.excella.reactor.domain;
 
 import javax.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 /**
  * This class represents an immutable skill, as defined in the domain, as opposed to a skill
@@ -17,5 +19,6 @@ public class Skill extends DomainModel {
 
   @ManyToOne(fetch = FetchType.EAGER, optional = false)
   @JoinColumn(name = "category_id")
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private SkillCategory category;
 }

--- a/src/main/resources/db/migration/V2__CreateSkillTables.sql
+++ b/src/main/resources/db/migration/V2__CreateSkillTables.sql
@@ -11,7 +11,8 @@ CREATE TABLE skill (
 
 ALTER TABLE skill
 ADD CONSTRAINT fk_skill_skcat
-FOREIGN KEY (category_id) REFERENCES skill_category(id);
+FOREIGN KEY (category_id) REFERENCES skill_category(id)
+ON DELETE CASCADE;
 
 CREATE INDEX idx_skill_skcat
 ON skill(category_id);


### PR DESCRIPTION
Also fixes an unintended bug that formerly tried to block infinite recursion in JSON by reference counting, but improperly subbed in values even in a non-recursive situation (removal of annotation on the DomainModel class).