### PR TITLE
Don't use throws for a RuntimeException.

### DIFF
--- a/src/main/java/com/excella/reactor/service/impl/UserDetailsServiceImpl.java
+++ b/src/main/java/com/excella/reactor/service/impl/UserDetailsServiceImpl.java
@@ -17,12 +17,9 @@ public class UserDetailsServiceImpl implements UserDetailsService {
   }
 
   @Override
-  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-    var user = userRepository.findByUsername(username);
-    if (user.isPresent()) {
-      return user.get();
-    } else {
-      throw new UsernameNotFoundException("username not found");
-    }
+  public UserDetails loadUserByUsername(String username) {
+    return userRepository
+        .findByUsername(username)
+        .orElseThrow(() -> new UsernameNotFoundException("username not found"));
   }
 }


### PR DESCRIPTION
`RuntimeException`'s don't need to be checked b/c they happen at runtime.