### PR TITLE
Updated boot version (2.2.0), cleaned startup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build
 *.iml
 .DS_Store
 .env
+.env.bak
 .envrc
 .java-version
 *.jks

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '2.1.5.RELEASE'
+	id 'org.springframework.boot' version '2.2.0.RELEASE'
 	id "io.franzbecker.gradle-lombok" version '3.0.0'
 	id 'com.github.sherter.google-java-format' version '0.8'
 	id 'jacoco'
@@ -11,7 +11,7 @@ apply plugin: 'io.spring.dependency-management'
 apply plugin: 'io.franzbecker.gradle-lombok'
 
 group = 'com.excella'
-version = '0.0.1-SNAPSHOT'
+version = '0.0.2-SNAPSHOT'
 sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
 
@@ -38,7 +38,7 @@ jacocoTestReport {
 	}
 
 	afterEvaluate {
-		classDirectories = files(classDirectories.files.collect {
+		classDirectories.setFrom files(classDirectories.files.collect {
 			fileTree(dir: it, exclude: ['com/excella/reactor/config/**', 'com/excella/reactor/ReactorApplication.class', 'com/excella/reactor/common/reactor/MonoUtils.class'])
 		})
 	}

--- a/build.gradle.xg
+++ b/build.gradle.xg
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '2.1.5.RELEASE'
+	id 'org.springframework.boot' version '2.2.0.RELEASE'
 	id "io.franzbecker.gradle-lombok" version '3.0.0'
 	id 'com.github.sherter.google-java-format' version '0.8'
 	id 'jacoco'
@@ -37,7 +37,7 @@ jacocoTestReport {
 	}
 
 	afterEvaluate {
-		classDirectories = files(classDirectories.files.collect {
+		classDirectories.setFrom files(classDirectories.files.collect {
 			fileTree(dir: it, exclude: ['com/excella/reactor/config/**', 'com/excella/reactor/ReactorApplication.class', 'com/excella/reactor/common/reactor/MonoUtils.class'])
 		})
 	}

--- a/start
+++ b/start
@@ -1,2 +1,4 @@
-docker-compose run -p 5005:5005 -p 8080:8080 api ./gradlew $@
+#!/bin/bash
+
+docker-compose run --service-ports api ./gradlew $@
 

--- a/test
+++ b/test
@@ -1,2 +1,4 @@
-docker-compose run -p 8080:8080 api /app/gradlew verGJF clean testNG jacocoTestReport jacocoTestCoverageVerification 
+#!/bin/bash
+
+docker-compose run --service-ports api /app/gradlew verGJF clean testNG jacocoTestReport jacocoTestCoverageVerification
 


### PR DESCRIPTION
- Upgraded Spring Boot to 2.2.0. Surprisingly, nothing broke in the tests.
- Fixed a deprecated method in the `build.gradle`
- Added bash meta line (whatever that thing is called) to `start` and `test` scripts, so editors and readers know its a shell script.
-  Updated flags on `docker-compose run` to use `--service-ports`; this just publishes all ports that are defined in the service in the compose file. No need to use specific ones.