### PR TITLE
Replace 'Projectname'

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,4 @@ pluginManagement {
 		gradlePluginPortal()
 	}
 }
-rootProject.name = 'projectname'
+rootProject.name = 'tcp-java'


### PR DESCRIPTION
Project name in Gradle settings was showing up in various places as just 'projectname' (e.g. SonarQube). Let's use the actual name of the project!