### PR TITLE
Productionize image

### DIFF
--- a/runjar
+++ b/runjar
@@ -1,0 +1,2 @@
+#!/bin/bash
+java -jar /app/build/libs/tcp-java*jar

--- a/runjar
+++ b/runjar
@@ -1,2 +1,0 @@
-#!/bin/bash
-java -jar /app/build/libs/tcp-java*jar

--- a/tcp-java-ecs/Dockerfile
+++ b/tcp-java-ecs/Dockerfile
@@ -2,7 +2,6 @@ FROM openjdk:11 AS builder
 
 WORKDIR /app
 # Fetch the gradle wrapper in a low layer:
-COPY /gradlew /gradle /.gradle ./
 COPY / .
 RUN ./gradlew --no-daemon
 
@@ -10,10 +9,11 @@ RUN df -m && free -m   #ls -altr; echo; cat .env
 
 # Prefix all non-comment lines in .env with "export ", write to export.env:
 RUN sed 's/^\([^#]\)/export \1/' .env > /app/export.env
-RUN . /app/export.env && ./gradlew --no-daemon --console plain bootJar
+RUN . /app/export.env && ./gradlew --no-daemon --console plain bootJar && \
+    mv /app/build/libs/tcp-java*jar /app/tcp-java.jar
 
 FROM openjdk:11
 WORKDIR /app
-COPY --from=builder /app /app
+COPY --from=builder /app/tcp-java.jar /app
 
-ENTRYPOINT ["/app/runjar"]
+ENTRYPOINT ["java", "-jar", "/app/tcp-java.jar"]

--- a/tcp-java-ecs/Dockerfile
+++ b/tcp-java-ecs/Dockerfile
@@ -1,0 +1,19 @@
+FROM openjdk:11 AS builder
+
+WORKDIR /app
+# Fetch the gradle wrapper in a low layer:
+COPY /gradlew /gradle /.gradle ./
+COPY / .
+RUN ./gradlew --no-daemon
+
+RUN df -m && free -m   #ls -altr; echo; cat .env
+
+# Prefix all non-comment lines in .env with "export ", write to export.env:
+RUN sed 's/^\([^#]\)/export \1/' .env > /app/export.env
+RUN . /app/export.env && ./gradlew --no-daemon --console plain bootJar
+
+FROM openjdk:11
+WORKDIR /app
+COPY --from=builder /app /app
+
+ENTRYPOINT ["/app/runjar"]

--- a/tcp-java-ecs/docker-compose.yml
+++ b/tcp-java-ecs/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.0"
 services:
   api:
-    image: 090999229429.dkr.ecr.us-east-1.amazonaws.com/tcp-java-api
+    image: 090999229429.dkr.ecr.${AWS_REGION}.amazonaws.com/tcp-java-api
     ports:
       - "8080:8080"
       - "5005:5005"

--- a/tcp-java-ecs/package-for-ecs
+++ b/tcp-java-ecs/package-for-ecs
@@ -58,11 +58,12 @@ DB_HOST=${DB_HOST}
 DB_PORT=${DB_PORT}
 DB_USER=${DB_USER}
 DB_PASSWORD=${DB_PASSWORD}
+AWS_REGION=${aws_region}
 EOF
 
 echo "Building the tcp-java-api Docker image..."
 # TODO: may need sudo, or to run this script as sudo?
-docker build -t tcp-java-api:latest .
+docker build -t tcp-java-api:latest . -f tcp-java-ecs/Dockerfile
 
 echo "Checking for the Docker image..."
 docker image ls | grep tcp-java-api


### PR DESCRIPTION
New Dockerfile: Build the JAR with gradlew bootJar, copy only the JAR over to the production image.
Fix the problem where we were always using the us-east-1 ECR.