### PR TITLE
NO SLEEP

### DIFF
--- a/Jenkinsfile-ocp
+++ b/Jenkinsfile-ocp
@@ -6,7 +6,7 @@ def REPO_URL = 'https://github.com/excellaco/tcp-java'
 pipeline {
     agent {
       node {
-        label 'openjdk-11-rhel7'
+        label 'maven'
       }
     }
     stages {
@@ -58,13 +58,23 @@ pipeline {
                     openshift.withCluster() {
                         openshift.withProject(DEV_ENV) {
                           def app = openshift.newApp("${S2I_IMAGE}~${REPO_URL}", "--name='${appName}'", "--strategy=source")
-                          sleep 5
                           def logs = app.narrow('bc').logs('-f')
                         }
                     }
                 }
               }
             }
+        stage('Start Build') {
+          steps {
+            script {
+                openshift.withCluster() {
+                    openshift.withProject(DEV_ENV) {
+                        def buildSelector = openshift.startBuild(appName, "--follow").narrow('bc')
+                    }
+                }
+            }
+          }
+        }
     }
 }
 


### PR DESCRIPTION
- Turns out there are only two available jenkins worker images: nodejs and maven. The maven one should have jdk11.
- Removed sleep as it is badwrong.
- Added a (sleepless) start build stage.